### PR TITLE
Mount asgi app on admin path

### DIFF
--- a/src/sqladmin_litestar_plugin/__init__.py
+++ b/src/sqladmin_litestar_plugin/__init__.py
@@ -97,7 +97,7 @@ class SQLAdminPlugin(InitPluginProtocol):
             by appending admin base_url stripped by the mounted route handler
             """
             app = scope["app"]
-            scope["path"] = self.admin.base_url + scope["path"]
+            scope["path"] = self.admin.base_url.rstrip("/") + scope["path"]
             try:
                 await self.app(scope, receive, send)  # type: ignore[arg-type]
             except Exception:
@@ -135,7 +135,7 @@ class PathFixMiddleware:
         orig_path = scope["path"]
         orig_raw = scope["raw_path"]
 
-        path = f"/{scope['path'].lstrip('/').rstrip('/')}"
+        path = f"/{scope['path'].rstrip('/').rstrip('/')}"
         if path == self.base_url:
             path = f"{path}/"
 

--- a/src/sqladmin_litestar_plugin/__init__.py
+++ b/src/sqladmin_litestar_plugin/__init__.py
@@ -135,7 +135,7 @@ class PathFixMiddleware:
         orig_path = scope["path"]
         orig_raw = scope["raw_path"]
 
-        path = f"/{scope['path'].rstrip('/').rstrip('/')}"
+        path = f"/{scope['path'].lstrip('/').rstrip('/')}"
         if path == self.base_url:
             path = f"{path}/"
 

--- a/src/sqladmin_litestar_plugin/__init__.py
+++ b/src/sqladmin_litestar_plugin/__init__.py
@@ -82,7 +82,9 @@ class SQLAdminPlugin(InitPluginProtocol):
         for view in self.views:
             self.admin.add_view(view)
 
-        @asgi(self.admin.base_url, is_mount=True)
+        mount_path = self.admin.base_url.rstrip("/")
+
+        @asgi(mount_path, is_mount=True)
         async def wrapped_app(scope: Scope, receive: Receive, send: Send) -> None:
             """Wraps the ASGI app to ensure the litestar app is set in the scope.
 
@@ -91,13 +93,13 @@ class SQLAdminPlugin(InitPluginProtocol):
             handling).
 
             Wrapped app is mounted on admin.base_url to ensure that main app requests will not be
-            recieved by mounted app, including those that should raise a 404 exception
-            
-            During the request handling, the function adjusts the request path 
+            received by mounted app, including those that should raise a 404 exception
+
+            During the request handling, the function adjusts the request path
             by appending admin base_url stripped by the mounted route handler
             """
             app = scope["app"]
-            scope["path"] = self.admin.base_url.rstrip("/") + scope["path"]
+            scope["path"] = f"{mount_path}/{scope['path']}"
             try:
                 await self.app(scope, receive, send)  # type: ignore[arg-type]
             except Exception:

--- a/src/sqladmin_litestar_plugin/__init__.py
+++ b/src/sqladmin_litestar_plugin/__init__.py
@@ -82,15 +82,22 @@ class SQLAdminPlugin(InitPluginProtocol):
         for view in self.views:
             self.admin.add_view(view)
 
-        @asgi("/", is_mount=True)
+        @asgi(self.admin.base_url, is_mount=True)
         async def wrapped_app(scope: Scope, receive: Receive, send: Send) -> None:
             """Wraps the ASGI app to ensure the litestar app is set in the scope.
 
             Starlette overwrites the app in the scope, so we need to ensure it is set back to the
             litestar app, in case it is needed after the request is handled (e.g., for exception
             handling).
+
+            Wrapped app is mounted on admin.base_url to ensure that main app requests will not be
+            recieved by mounted app, including those that should raise a 404 exception
+            
+            During the request handling, the function adjusts the request path 
+            by appending admin base_url stripped by the mounted route handler
             """
             app = scope["app"]
+            scope["path"] = self.admin.base_url + scope["path"]
             try:
                 await self.app(scope, receive, send)  # type: ignore[arg-type]
             except Exception:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -41,7 +41,7 @@ def test_views_added_to_admin_app(plugin: SQLAdminPlugin, monkeypatch: pytest.Mo
 
 
 @pytest.mark.parametrize("should_raise", [True, False])
-@pytest.mark.anyio()
+@pytest.mark.anyio
 async def test_resets_app_in_scope(
     *, should_raise: bool, plugin: SQLAdminPlugin, app: Litestar, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -52,8 +52,8 @@ async def test_resets_app_in_scope(
         mock()
 
     monkeypatch.setattr(plugin, "app", fake_admin_app)
-    handler = app.route_handler_method_map["/"]["asgi"].fn
-    fake_scope = {"app": app}
+    handler = app.route_handler_method_map["/admin"]["asgi"].fn
+    fake_scope = {"app": app, "path": "/"}
 
     await handler(fake_scope, MagicMock(), MagicMock())
     assert fake_scope["app"] == app
@@ -74,7 +74,7 @@ async def test_resets_app_in_scope(
         ("admin/other/", "/admin/other"),
     ],
 )
-@pytest.mark.anyio()
+@pytest.mark.anyio
 async def test_path_fix_middleware(path: str, expected: str, *, should_raise: bool) -> None:
     from starlette.types import Receive, Scope, Send  # noqa: PLC0415, F401
 


### PR DESCRIPTION
Mounts the asgi application on the litestar application at the path that the wrapped admin application uses.

This prevents litestar from routing to the admin app where it otherwise shouldn't.

Closes #15 

Supersedes #17
