### PR TITLE
fix: incorrect path passed to asgi app

### DIFF
--- a/src/sqladmin_litestar_plugin/__init__.py
+++ b/src/sqladmin_litestar_plugin/__init__.py
@@ -99,12 +99,14 @@ class SQLAdminPlugin(InitPluginProtocol):
             by appending admin base_url stripped by the mounted route handler
             """
             app = scope["app"]
-            scope["path"] = f"{mount_path}/{scope['path']}"
+            path = scope["path"]
+            scope["path"] = f"{mount_path}{path}"
             try:
                 await self.app(scope, receive, send)  # type: ignore[arg-type]
             except Exception:
                 logger.exception("Error raised from SQLAdmin app")
             scope["app"] = app
+            scope["path"] = path
 
         app_config.route_handlers.append(wrapped_app)
         return app_config


### PR DESCRIPTION
Fix issue introduced in #27 that caused the admin app to receive paths with a double-forward slash, e.g., `/admin//something`.

Adds logic to reset the `scope['path']` value on exit of the wrapped asgi app handler.